### PR TITLE
Fix implementation of WimMessageScanning

### DIFF
--- a/src/Microsoft.Wim/Enums.cs
+++ b/src/Microsoft.Wim/Enums.cs
@@ -371,6 +371,22 @@ namespace Microsoft.Wim
     }
 
     /// <summary>
+    /// Specifies what the count represents for a <see cref="WimMessageScanning"/> object.
+    /// </summary>
+    public enum WimMessageScanningType
+    {
+        /// <summary>
+        /// The count is the number of files scanned.
+        /// </summary>
+        Files = 0,
+
+        /// <summary>
+        /// The count is the number of directories scanned.
+        /// </summary>
+        Directories = 1
+    }
+
+    /// <summary>
     /// Specifies the type of message sent to the WIMMessageCallback.
     /// </summary>
     [SuppressMessage("Microsoft.Design", "CA1008:EnumsShouldHaveZeroValue")]

--- a/src/Microsoft.Wim/WimMessage.cs
+++ b/src/Microsoft.Wim/WimMessage.cs
@@ -500,24 +500,35 @@ namespace Microsoft.Wim
         internal WimMessageScanning(IntPtr wParam, IntPtr lParam)
             : base(wParam, lParam)
         {
-            // Marshal the directory count
+            // If wParam is 0, lParam is a file count
+            // If wParam is 1, lParam is a directory count
             //
             Param1 = (int)wParam;
 
-            // Marshal to file count
+            // Marshal to file or directory count
             //
             Param2 = (int)lParam;
         }
 
         /// <summary>
-        /// Gets the number of directories that were scanned.
+        /// Gets the number of directories that were scanned if <see cref="IsDirectoryCount"/> is <code>true</code>, otherwise zero.
         /// </summary>
-        public int DirectoryCount => Param1;
+        public int DirectoryCount => IsDirectoryCount ? Param2 : 0;
 
         /// <summary>
-        /// Gets the number of files that were scanned.
+        /// Gets the number of files that were scanned if <see cref="IsFileCount"/> is <code>true</code>, otherwise zero.
         /// </summary>
-        public int FileCount => Param2;
+        public int FileCount => IsFileCount ? Param2 : 0;
+
+        /// <summary>
+        /// Gets a value indicating if the message contains a directory count.
+        /// </summary>
+        public bool IsDirectoryCount => Param1 == 1;
+
+        /// <summary>
+        /// Gets a value indicating if the message contains a file count.
+        /// </summary>
+        public bool IsFileCount => !IsDirectoryCount;
     }
 
     /// <summary>

--- a/src/Microsoft.Wim/WimMessage.cs
+++ b/src/Microsoft.Wim/WimMessage.cs
@@ -511,14 +511,14 @@ namespace Microsoft.Wim
         }
 
         /// <summary>
-        /// Gets the number of objects that were scanned.  Use the <see cref="WimMessageScanningType"/> property to determine if the count represents files or directories.
+        /// Gets the number of objects that were scanned.  Use the <see cref="CountType"/> property to determine if the count represents files or directories.
         /// </summary>
         public int Count => Param2;
 
         /// <summary>
-        /// Gets a value indicating what <see cref="WimMessageScanningType"/> that the <see cref="Count"/> property represents.
+        /// Gets a value indicating what <see cref="CountType"/> that the <see cref="Count"/> property represents.
         /// </summary>
-        public WimMessageScanningType WimMessageScanningType => (WimMessageScanningType)Param1;
+        public WimMessageScanningType CountType => (WimMessageScanningType)Param1;
     }
 
     /// <summary>

--- a/src/Microsoft.Wim/WimMessage.cs
+++ b/src/Microsoft.Wim/WimMessage.cs
@@ -511,24 +511,14 @@ namespace Microsoft.Wim
         }
 
         /// <summary>
-        /// Gets the number of directories that were scanned if <see cref="IsDirectoryCount"/> is <code>true</code>, otherwise zero.
+        /// Gets the number of objects that were scanned.  Use the <see cref="WimMessageScanningType"/> property to determine if the count represents files or directories.
         /// </summary>
-        public int DirectoryCount => IsDirectoryCount ? Param2 : 0;
+        public int Count => Param2;
 
         /// <summary>
-        /// Gets the number of files that were scanned if <see cref="IsFileCount"/> is <code>true</code>, otherwise zero.
+        /// Gets a value indicating what <see cref="WimMessageScanningType"/> that the <see cref="Count"/> property represents.
         /// </summary>
-        public int FileCount => IsFileCount ? Param2 : 0;
-
-        /// <summary>
-        /// Gets a value indicating if the message contains a directory count.
-        /// </summary>
-        public bool IsDirectoryCount => Param1 == 1;
-
-        /// <summary>
-        /// Gets a value indicating if the message contains a file count.
-        /// </summary>
-        public bool IsFileCount => !IsDirectoryCount;
+        public WimMessageScanningType WimMessageScanningType => (WimMessageScanningType)Param1;
     }
 
     /// <summary>


### PR DESCRIPTION
Turns out the documentation is wrong.  If `wParam` is 0, then `lParam` is a file count.  If `wParam` is 1, then `lParam` is a directory count.

Added `IsDirectoryCount` and `IsFileCount` so that callers can distinguish.

Fixes #17